### PR TITLE
Change Request.read_form() to always return an empty form object

### DIFF
--- a/lib/message/request.lua
+++ b/lib/message/request.lua
@@ -174,11 +174,8 @@ function Request:read_form(maxsize, filetmpl)
     if form then
         return form
     elseif not self.content then
-        if self.method == 'POST' then
-            self.form = new_form()
-            return self.form
-        end
-        return nil
+        self.form = new_form()
+        return self.form
     end
 
     local mime, err, params = self.header:content_type()


### PR DESCRIPTION
This pull request modifies the `Request:read_form` function in `lib/message/request.lua` to simplify the logic for handling form data. The key change removes a conditional check for the `POST` method, streamlining the code.

Code simplification:

* [`lib/message/request.lua`](diffhunk://#diff-3a259052689319db4ca55de747afb5ad502f94c6283ae3103b794a680c68e54fL177-L182): Removed the conditional check for the `POST` method within the `Request:read_form` function, ensuring that the form is initialized consistently regardless of the HTTP method.