### PR TITLE
Move message parsing logic into request and response modules

### DIFF
--- a/lib/connection.lua
+++ b/lib/connection.lua
@@ -20,21 +20,12 @@
 -- THE SOFTWARE.
 --
 --- assign to local
-local sub = string.sub
 local errorf = require('error').format
 local new_reader = require('net.http.reader').new
 local new_writer = require('net.http.writer').new
-local new_request = require('net.http.message.request').new
-local new_response = require('net.http.message.response').new
-local new_content = require('net.http.content').new
-local new_chunked_content = require('net.http.content.chunked').new
-local parse = require('net.http.parse')
-local parse_request = parse.request
-local parse_response = parse.response
+local parse_request = require('net.http.message.request').parse
+local parse_response = require('net.http.message.response').parse
 --- constants
--- need more bytes
-local EAGAIN = parse.EAGAIN
-local EMSG = parse.EMSG
 --- parse error code to http status code
 local DEFAULT_READSIZE = 4096
 
@@ -89,91 +80,12 @@ function Connection:flush()
     return n, nil, timeout
 end
 
---- read_message
---- @param msg net.http.message
---- @param parser function
---- @return boolean ok
---- @return any err
---- @return boolean? timeout
-function Connection:read_message(msg, parser)
-    local reader = self.reader
-    local readsize = self.readsize
-    local header = msg.header
-    local str = ''
-
-    msg.header = header.dict
-    while true do
-        local s, err, timeout = reader:read(readsize)
-        if err then
-            return false, errorf('failed to read_message()', err)
-        elseif not s then
-            return false, nil, timeout
-        end
-        str = str .. s
-
-        -- TODO: add methods to sets the MAX_MSGLEN, MAX_HDRLEN and MAX_HDRNUM
-        -- parse message
-        -- parser(str, tbl, MAX_MSGLEN, MAX_HDRLEN, MAX_HDRNUM)
-        local cur
-        cur, err = parser(str, msg)
-        -- parsed
-        if cur then
-            -- prepend extra data
-            reader:prepend(sub(str, cur + 1))
-
-            -- create header
-            msg.header = header
-
-            -- 3.3.3.  Message Body Length
-            -- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3
-            --
-            -- If a message is received with both a Transfer-Encoding and a
-            -- Content-Length header field, the Transfer-Encoding overrides the
-            -- Content-Length.
-            --
-            -- Such a message might indicate an attempt to perform request
-            -- smuggling (Section 9.5) or response splitting (Section 9.4) and
-            -- ought to be handled as an error.
-            --
-            -- A sender MUST remove the received Content-Length field prior to
-            -- forwarding such a message downstream.
-            --
-            local len = header:content_length()
-            if header:is_transfer_encoding_chunked() then
-                msg.content = new_chunked_content(reader)
-            elseif len and len > 0 then
-                msg.content = new_content(reader, len)
-            end
-
-            return true
-
-        elseif err.type ~= EAGAIN then
-            -- parse error
-            return false, err
-        end
-        -- more bytes need
-    end
-end
-
 --- read_request
 --- @return net.http.message.request? req
 --- @return any err
 --- @return boolean? timeout
 function Connection:read_request()
-    local req = new_request()
-    local ok, err, timeout = self:read_message(req, parse_request)
-    if ok then
-        -- parse-uri
-        ok, err = req:set_uri(req.uri, true)
-        if not ok then
-            -- invalid uri format
-            return nil, EMSG:new('failed to read_request()', err)
-        end
-        return req
-    elseif err then
-        return nil, errorf('failed to read_request()', err)
-    end
-    return nil, nil, timeout
+    return parse_request(self.reader, self.readsize)
 end
 
 --- read_response
@@ -181,16 +93,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Connection:read_response()
-    local res = new_response()
-    local ok, err, timeout = self:read_message(res, parse_response)
-
-    if ok then
-        return res
-    elseif err then
-        return nil, errorf('failed to read_response()', err)
-    end
-    return nil, nil, timeout
-
+    return parse_response(self.reader, self.readsize)
 end
 
 return {

--- a/lib/message.lua
+++ b/lib/message.lua
@@ -274,6 +274,7 @@ function Message:write(w, data)
         return len
     end
 
+    --- @cast data string
     local n, err, timeout = w:write(data)
     if err then
         return nil, errorf('failed to write()', err)
@@ -283,7 +284,82 @@ function Message:write(w, data)
     return len + n
 end
 
+--- parse_message parse a message from a string
+--- @param _ string
+--- @return integer? cur position of the next character to read
+--- @return any err
+function Message:parse_message(_)
+    return nil, errorf(2, 'parse_message() is not implemented')
+end
+
+local sub = string.sub
+local new_content = require('net.http.content').new
+local new_chunked_content = require('net.http.content.chunked').new
+--- constants
+-- need more bytes
+local EAGAIN = require('net.http.parse').EAGAIN
+
+--- read_message
+--- @param reader net.http.reader
+--- @param readsize integer
+--- @param parser fun(str:string, msg:net.http.message): (pos: integer?, err:any)
+--- @param msg net.http.message
+--- @return boolean ok
+--- @return any err
+--- @return boolean? timeout
+local function parse(reader, readsize, parser, msg)
+    local str = ''
+    while true do
+        local s, err, timeout = reader:read(readsize)
+        if err then
+            return false, errorf('failed to message.parse()', err)
+        elseif not s then
+            return false, nil, timeout
+        end
+        str = str .. s
+
+        -- TODO: add methods to sets the MAX_MSGLEN, MAX_HDRLEN and MAX_HDRNUM
+        -- parse message
+        -- parser(str, tbl, MAX_MSGLEN, MAX_HDRLEN, MAX_HDRNUM)
+        local cur
+        cur, err = parser(str, msg)
+        -- parsed
+        if cur then
+            -- prepend extra data
+            reader:prepend(sub(str, cur + 1))
+
+            -- 3.3.3.  Message Body Length
+            -- https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3
+            --
+            -- If a message is received with both a Transfer-Encoding and a
+            -- Content-Length header field, the Transfer-Encoding overrides the
+            -- Content-Length.
+            --
+            -- Such a message might indicate an attempt to perform request
+            -- smuggling (Section 9.5) or response splitting (Section 9.4) and
+            -- ought to be handled as an error.
+            --
+            -- A sender MUST remove the received Content-Length field prior to
+            -- forwarding such a message downstream.
+            --
+            local len = msg.header:content_length()
+            if msg.header:is_transfer_encoding_chunked() then
+                msg.content = new_chunked_content(reader)
+            elseif len and len > 0 then
+                msg.content = new_content(reader, len)
+            end
+            return true
+
+        elseif err.type ~= EAGAIN then
+            -- parse error
+            return false, err
+        end
+        -- more bytes need
+    end
+end
+
 return {
+    parse = parse,
     new = require('metamodule').new(Message),
 }
 

--- a/lib/message/request.lua
+++ b/lib/message/request.lua
@@ -357,6 +357,50 @@ function Request:write_form(w, form, boundary)
     return res, err
 end
 
+local http_parse_request = require('net.http.parse').request
+
+--- parse_message parse a request message from a string
+--- @param str string
+--- @param msg net.http.message.request
+--- @return integer? cur position of the next character to read
+--- @return any err
+local function parse_request(str, msg)
+    local header = msg.header
+    msg.header = header.dict
+    local cur, err = http_parse_request(str, msg)
+    msg.header = header
+    return cur, err
+end
+
+local new_request = require('metamodule').new(Request, 'net.http.message')
+local message_parse = require('net.http.message').parse
+-- invalid message error
+local EMSG = require('net.http.parse').EMSG
+
+--- parse a request message from a reader
+--- @param reader net.http.reader
+--- @param readsize integer
+--- @return net.http.message.request? req
+--- @return any err
+--- @return boolean? timeout
+local function parse(reader, readsize)
+    local req = new_request()
+    local ok, err, timeout = message_parse(reader, readsize, parse_request, req)
+    if ok then
+        -- parse-uri
+        ok, err = req:set_uri(req.uri, true)
+        if not ok then
+            -- invalid uri format
+            return nil, EMSG:new('failed to request.parse()', err)
+        end
+        return req
+    elseif err then
+        return nil, errorf('failed to request.parse()', err)
+    end
+    return nil, nil, timeout
+end
+
 return {
-    new = require('metamodule').new(Request, 'net.http.message'),
+    parse = parse,
+    new = new_request,
 }

--- a/lib/message/response.lua
+++ b/lib/message/response.lua
@@ -74,6 +74,43 @@ function Response:write_firstline(w)
     return n
 end
 
+local http_parse_response = require('net.http.parse').response
+
+--- parse_message parse a response message from a string
+--- @param str string
+--- @param msg net.http.message.response
+--- @return integer? cur position of the next character to read
+--- @return any err
+local function parse_response(str, msg)
+    local header = msg.header
+    msg.header = header.dict
+    local cur, err = http_parse_response(str, msg)
+    msg.header = header
+    return cur, err
+end
+
+local new_response = require('metamodule').new(Response, 'net.http.message')
+local parse_message = require('net.http.message').parse
+
+--- parse a response message from a reader
+--- @param reader net.http.reader
+--- @param readsize integer
+--- @return net.http.message.response? res
+--- @return any err
+--- @return boolean? timeout
+local function parse(reader, readsize)
+    local res = new_response()
+    local ok, err, timeout =
+        parse_message(reader, readsize, parse_response, res)
+    if ok then
+        return res
+    elseif err then
+        return nil, errorf('failed to response.parse()', err)
+    end
+    return nil, nil, timeout
+end
+
 return {
-    new = require('metamodule').new(Response, 'net.http.message'),
+    parse = parse,
+    new = new_response,
 }


### PR DESCRIPTION
This pull request refactors the HTTP message parsing logic to improve modularity and maintainability. Key changes include consolidating parsing logic into reusable functions, simplifying `Connection` methods, and introducing dedicated `parse` functions for requests and responses.

### Refactoring and Modularization:

* **Consolidation of Parsing Logic**:
  - Moved the `read_message` function from `lib/connection.lua` to `lib/message.lua` as a reusable `parse` function, improving code reusability and separation of concerns. [[1]](diffhunk://#diff-fdfa7c6397054e533f499acefb5c77cb5732b7687b9ff639b7c307f710724b1fL92-R96) [[2]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9R287-R362)

* **Dedicated Parse Functions**:
  - Added `parse_request` in `lib/message/request.lua` to handle request parsing, replacing the inline logic in `Connection:read_request`.
  - Added `parse_response` in `lib/message/response.lua` to handle response parsing, replacing the inline logic in `Connection:read_response`.

### Simplification of `Connection` Methods:

* **Simplified `Connection:read_request` and `Connection:read_response`**:
  - These methods now directly call the respective `parse_request` and `parse_response` functions, reducing code duplication and complexity.

### Minor Enhancements:

* **Type Casting in `Message:write`**:
  - Added a type cast annotation for the `data` parameter in `lib/message.lua` to improve type safety.
