### PR TITLE
Change the type of the filter argument of Responder.init method

### DIFF
--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -67,7 +67,7 @@ function Responder:init(writer, mime, filter)
         fatalf('mime must have a getmime() method')
     end
     -- check whether the filter is a callable or nil.
-    checkopt.callable(filter, nil, 'filter')
+    checkopt.func(filter, nil, 'filter')
 
     self.writer = writer
     self.mime = mime

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -84,8 +84,7 @@ function testcase.new()
 
     -- test that throws an error if filter is not a function
     err = assert.throws(new_responder, writer, mime, {})
-    assert.match(err,
-                 "bad argument 'filter' .+callable object expected, got table",
+    assert.match(err, "bad argument 'filter' .+function expected, got table",
                  false)
 end
 


### PR DESCRIPTION
This pull request updates the `Responder` class and its corresponding test suite to enforce stricter type checking for the `filter` parameter. The key changes involve replacing the validation for a "callable" object with a stricter requirement for a "function."

### Changes to type checking in `Responder`:

* [`lib/responder.lua`](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L70-R70): Replaced the validation method `checkopt.callable` with `checkopt.func` to ensure the `filter` parameter is explicitly a function rather than any callable object.

### Updates to test cases:

* [`test/responder_test.lua`](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L87-R87): Updated the error message assertion in the test case to reflect the stricter type requirement, changing "callable object" to "function."