### PR TITLE
Fix Responder.bytes_out() not returning per-instance sent bytes

### DIFF
--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -44,6 +44,7 @@ local code2message = require('net.http.status').code2message
 --- @field private mime mime
 --- @field private filter net.http.responder.filter
 --- @field private message net.http.message.response
+--- @field private start_bytes integer
 local Responder = {}
 
 --- init
@@ -65,6 +66,11 @@ function Responder:init(writer, mime, filter)
     -- check whether the filter is a callable or nil.
     checkopt.func(filter, nil, 'filter')
 
+    -- check whether the writer:bytes_out() returns a number
+    self.start_bytes = writer:bytes_out()
+    assert(type(self.start_bytes) == 'number',
+           'writer:bytes_out() must return a number')
+
     self.writer = writer
     self.mime = mime
     self.filter = filter
@@ -76,7 +82,7 @@ end
 --- bytes_out returns the number of bytes written to the writer.
 --- @return integer n
 function Responder:bytes_out()
-    return self.writer:bytes_out()
+    return self.writer:bytes_out() - self.start_bytes
 end
 
 --- write a data string to the writer.

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -155,6 +155,11 @@ end
 
 function testcase.bytes_out()
     local data = {}
+    local clear_data = function()
+        for i = 1, #data do
+            data[i] = nil
+        end
+    end
     local writer = new_writer(data)
     local res = new_responder(writer)
     assert(res:write('foo'))
@@ -165,8 +170,20 @@ function testcase.bytes_out()
 
     -- test that bytes_out returns the number of bytes written to the writer
     assert(res:flush())
-    assert.equal(res:bytes_out(), #(table.concat(data)))
+    local nbyte = #(table.concat(data))
+    assert.equal(res:bytes_out(), nbyte)
     assert.equal(res:bytes_out(), writer:bytes_out())
+
+    -- test that bytes_out returns corret number of bytes even reuse the writer
+    res = new_responder(writer)
+    assert.equal(res:bytes_out(), 0)
+    assert.equal(writer:bytes_out(), nbyte)
+    clear_data()
+    assert(res:write('bar'))
+    res:flush()
+    nbyte = nbyte + #(table.concat(data))
+    assert.equal(res:bytes_out(), #(table.concat(data)))
+    assert.equal(writer:bytes_out(), nbyte)
 end
 
 function testcase.write_file()


### PR DESCRIPTION
Previously, Responder.bytes_out() returned the total bytes sent by the underlying writer. However, the writer object can be reused across multiple requests, causing incorrect byte counts per Responder.
