### PR TITLE
Rename Message.has_-prefixed methods to use the is_ prefix

### DIFF
--- a/lib/message.lua
+++ b/lib/message.lua
@@ -75,9 +75,9 @@ function Message:set_version(version)
     return true
 end
 
---- has_firstline_sent returns true if the first line has been sent
+--- is_firstline_sent returns true if the first line has been sent
 --- @return boolean ok
-function Message:has_firstline_sent()
+function Message:is_firstline_sent()
     return self.firstline_sent ~= nil
 end
 
@@ -87,16 +87,16 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Message:write_firstline(w)
-    if self:has_firstline_sent() then
+    if self:is_firstline_sent() then
         fatalf(2, 'the first line has already been sent')
     end
     self.firstline_sent = 0
     return 0
 end
 
---- has_header_sent returns true if the header has been sent
+--- is_header_sent returns true if the header has been sent
 --- @return boolean ok
-function Message:has_header_sent()
+function Message:is_header_sent()
     return self.header_sent ~= nil
 end
 
@@ -108,7 +108,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 local function write_header(self, w, with_content)
-    if self:has_header_sent() then
+    if self:is_header_sent() then
         fatalf(2, 'the headers have already been sent')
     end
     self.header_sent = 0
@@ -120,7 +120,7 @@ local function write_header(self, w, with_content)
     end
 
     local len = 0
-    if not self:has_firstline_sent() then
+    if not self:is_firstline_sent() then
         -- write firstline
         local n, err, timeout = self:write_firstline(w)
         if err then
@@ -163,7 +163,7 @@ function Message:write_content(w, content)
     end
 
     local len = 0
-    if not self:has_header_sent() then
+    if not self:is_header_sent() then
         local header = self.header
 
         if content.is_chunked then
@@ -218,7 +218,7 @@ function Message:write_file(w, file)
     local offset = file:seek()
     local size = stat.size - offset
 
-    if not self:has_header_sent() then
+    if not self:is_header_sent() then
         self.header:set('Content-Length', tostring(size))
         -- write header
         local n, timeout
@@ -277,7 +277,7 @@ function Message:write(w, data)
 
     local len = 0
 
-    if not self:has_header_sent() then
+    if not self:is_header_sent() then
         self.header:set('Content-Length', tostring(size))
         -- write header
         local n, err, timeout = write_header(self, w, size > 0)

--- a/lib/message/request.lua
+++ b/lib/message/request.lua
@@ -204,7 +204,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Request:write_firstline(w)
-    if self:has_firstline_sent() then
+    if self:is_firstline_sent() then
         fatalf(2, 'the first line has already been sent')
     end
     self.firstline_sent = 0
@@ -283,7 +283,7 @@ local function write_form(self, w, form, boundary, tmpfiles)
     end
 
     local nsent = 0
-    if not self:has_header_sent() then
+    if not self:is_header_sent() then
         local header = self.header
 
         -- write header

--- a/lib/message/response.lua
+++ b/lib/message/response.lua
@@ -61,7 +61,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Response:write_firstline(w)
-    if self:has_firstline_sent() then
+    if self:is_firstline_sent() then
         fatalf(2, 'the first line has already been sent')
     end
     self.firstline_sent = 0

--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -145,7 +145,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Responder:reply_file(code, file)
-    if self.message:has_firstline_sent() then
+    if self.message:is_firstline_sent() then
         return false, errorf('cannot send a response message more than once')
     end
 
@@ -205,7 +205,7 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Responder:reply(code, data, as_json)
-    if self.message:has_firstline_sent() then
+    if self.message:is_firstline_sent() then
         -- cannot send a status code twice
         return false, errorf('cannot send a response message more than once')
     end

--- a/test/message_test.lua
+++ b/test/message_test.lua
@@ -48,16 +48,16 @@ function testcase.write_firstline()
     assert.match(err, 'the first line has already been sent')
 end
 
-function testcase.has_firstline_sent()
+function testcase.is_firstline_sent()
     local m = assert(new_message())
 
-    -- test that has_firstline_sent returns false before firstline is sent
-    assert.is_false(m:has_firstline_sent())
+    -- test that is_firstline_sent returns false before firstline is sent
+    assert.is_false(m:is_firstline_sent())
 
-    -- test that has_firstline_sent returns true after firstline is sent
+    -- test that is_firstline_sent returns true after firstline is sent
     local w = new_writer({})
     assert(m:write_firstline(w))
-    assert.is_true(m:has_firstline_sent())
+    assert.is_true(m:is_firstline_sent())
 end
 
 function testcase.write_header()
@@ -104,17 +104,17 @@ function testcase.write_header()
     assert.match(err, 'the headers have already been sent')
 end
 
-function testcase.has_header_sent()
+function testcase.is_header_sent()
     local m = assert(new_message())
 
-    -- test that has_header_sent returns false before header is sent
-    assert.is_false(m:has_header_sent())
+    -- test that is_header_sent returns false before header is sent
+    assert.is_false(m:is_header_sent())
 
-    -- test that has_header_sent returns true after header is sent
+    -- test that is_header_sent returns true after header is sent
     local w = new_writer({})
     m.header:set('foo', 'bar')
     assert(m:write_header(w))
-    assert.is_true(m:has_header_sent())
+    assert.is_true(m:is_header_sent())
 end
 
 function testcase.write_content()


### PR DESCRIPTION
This pull request refactors method names across multiple files for better readability and consistency. Specifically, it replaces `has_firstline_sent` and `has_header_sent` with `is_firstline_sent` and `is_header_sent`, respectively. The changes span the main codebase and corresponding test cases.

### Refactoring for consistency:

* Renamed `Message:has_firstline_sent` to `Message:is_firstline_sent` and updated all references in `lib/message.lua`, `lib/message/request.lua`, `lib/message/response.lua`, and `lib/responder.lua`. This ensures method names align with boolean-returning conventions. [[1]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L78-R80) [[2]](diffhunk://#diff-3a259052689319db4ca55de747afb5ad502f94c6283ae3103b794a680c68e54fL207-R207) [[3]](diffhunk://#diff-501c32b1e566452aeee0e1a528fa229e9dead75072c399383d97b8c78d10a6acL64-R64) [[4]](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L148-R148) [[5]](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L208-R208)

* Renamed `Message:has_header_sent` to `Message:is_header_sent` and updated all references in `lib/message.lua` and `lib/message/request.lua`. This change improves clarity and consistency with the naming convention used for similar methods. [[1]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L90-R99) [[2]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L111-R111) [[3]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L123-R123) [[4]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L166-R166) [[5]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L221-R221) [[6]](diffhunk://#diff-77b42f6dba2664074e9cc154c7ba95d1f53ad9750005b3807ef75018e04c17a9L280-R280) [[7]](diffhunk://#diff-3a259052689319db4ca55de747afb5ad502f94c6283ae3103b794a680c68e54fL286-R286)

### Test case updates:

* Updated test cases in `test/message_test.lua` to reflect the method renaming, ensuring that tests now use `is_firstline_sent` and `is_header_sent` instead of the old method names. This maintains alignment between the code and its tests. [[1]](diffhunk://#diff-1aa3f6e9494ad8ae5232b6cba45f6742bf31896ce9457cff0b9788a2e82dd235L51-R60) [[2]](diffhunk://#diff-1aa3f6e9494ad8ae5232b6cba45f6742bf31896ce9457cff0b9788a2e82dd235L107-R117)