### PR TITLE
Add responder.is_ methods

### DIFF
--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -91,6 +91,12 @@ function Responder:is_firstline_sent()
     return self.message:is_firstline_sent()
 end
 
+--- is_header_sent returns true if the response headers have been sent.
+--- @return boolean ok
+function Responder:is_header_sent()
+    return self.message:is_header_sent()
+end
+
 --- write a data string to the writer.
 --- if the error or timeout occurs, then returns false, err, timeout,
 --- otherwise, returns a true

--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -85,6 +85,12 @@ function Responder:bytes_out()
     return self.writer:bytes_out() - self.start_bytes
 end
 
+--- is_firstline_sent returns true if the first line of the response message has been sent.
+--- @return boolean ok
+function Responder:is_firstline_sent()
+    return self.message:is_firstline_sent()
+end
+
 --- write a data string to the writer.
 --- if the error or timeout occurs, then returns false, err, timeout,
 --- otherwise, returns a true

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -199,6 +199,19 @@ function testcase.is_firstline_sent()
     assert.is_true(res:is_firstline_sent())
 end
 
+function testcase.is_header_sent()
+    local data = {}
+    local writer = new_writer(data)
+    local res = new_responder(writer)
+
+    -- test that is_header_sent() returns false before write() is called
+    assert.is_false(res:is_header_sent())
+
+    -- test that is_header_sent() returns true after write() is called
+    assert(res:write('foo'))
+    assert.is_true(res:is_header_sent())
+end
+
 function testcase.write_file()
     local data = {}
     local writer = new_writer(data)

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -186,6 +186,19 @@ function testcase.bytes_out()
     assert.equal(writer:bytes_out(), nbyte)
 end
 
+function testcase.is_firstline_sent()
+    local data = {}
+    local writer = new_writer(data)
+    local res = new_responder(writer)
+
+    -- test that is_firstline_sent() returns false before write() is called
+    assert.is_false(res:is_firstline_sent())
+
+    -- test that is_firstline_sent() returns true after write() is called
+    assert(res:write('foo'))
+    assert.is_true(res:is_firstline_sent())
+end
+
 function testcase.write_file()
     local data = {}
     local writer = new_writer(data)


### PR DESCRIPTION
This pull request adds new methods to the `Responder` class to check the status of response message components and includes corresponding test cases to ensure their functionality. These changes improve the ability to inspect the state of the response during its lifecycle.

### Enhancements to `Responder` functionality:

* Added `Responder:is_firstline_sent()` method to check if the first line of the response message has been sent.
* Added `Responder:is_header_sent()` method to check if the response headers have been sent.

### Corresponding test cases:

* Added `testcase.is_firstline_sent()` to verify the behavior of the `is_firstline_sent()` method before and after calling `write()`.
* Added `testcase.is_header_sent()` to verify the behavior of the `is_header_sent()` method before and after calling `write()`.