### PR TITLE
Refactor HTTP response status handling for HTTP RFC compliance

### DIFF
--- a/lib/message/response.lua
+++ b/lib/message/response.lua
@@ -47,8 +47,7 @@ end
 --- @return any err
 function Response:set_status(code)
     if not code2name(code) then
-        return false, errorf(
-                   'failed to set_status(): unsupported status code %d', code)
+        return false, errorf('unsupported status code %d', code)
     end
 
     self.status = code

--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -147,6 +147,35 @@ function Responder:flush()
     return true
 end
 
+--- check_reply_args checks the arguments for the reply methods.
+--- if the message is already sent, then throws an error.
+--- if the status code is not valid, then throws an error.
+--- if the data is not nil and the status code is 1xx, 204, 205 or 304,
+--- then throws an error.
+--- @param msg net.http.message.response
+--- @param code integer
+--- @param data any
+local function check_reply_args(msg, code, data)
+    if msg:is_firstline_sent() then
+        fatalf(3, 'cannot send a response message more than once')
+    end
+
+    -- set status code
+    local ok, err = msg:set_status(code)
+    if not ok then
+        fatalf(3, 'failed to set status code: %s', err)
+    end
+
+    -- throws an error if the code that should not have a body is set
+    --  * 1xx Informational
+    --  * 204 No Content
+    --  * 205 Reset Content
+    --  * 304 Not Modified
+    if data ~= nil and (code < 200 or code == 204 or code == 205 or code == 304) then
+        fatalf(3, '%s response cannot have a content body', code2message(code))
+    end
+end
+
 --- reply_file a write a file content to the writer.
 --- if the Content-Type header is not set, then determine the content type from
 --- the file extension and set it to the 'Content-Type' header. if the content type
@@ -157,23 +186,11 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Responder:reply_file(code, file)
-    if self.message:is_firstline_sent() then
-        return false, errorf('cannot send a response message more than once')
-    end
+    check_reply_args(self.message, code, file)
 
     local filetype = type(file)
     assert(filetype == 'string' or is_file(file),
            'file must be a string or file*')
-
-    -- set status code
-    local ok, err = self.message:set_status(code)
-    if not ok then
-        return false, err
-    elseif code == 204 then
-        -- ignore file for 204 No Content response
-        self.header:set('Content-Length', '0')
-        return self:write('')
-    end
 
     -- set 'Content-Type' header
     if not self.header:get('Content-Type') then
@@ -198,12 +215,11 @@ function Responder:reply_file(code, file)
         return self:write_file(file)
     end
 
-    local f
-    f, err = fopen(file)
+    local f, err = fopen(file)
     if not f then
         return false, errorf('failed to open a file', err)
     end
-    local timeout
+    local ok, timeout
     ok, err, timeout = self:write_file(f)
     f:close()
     return ok, err, timeout
@@ -217,48 +233,32 @@ end
 --- @return any err
 --- @return boolean? timeout
 function Responder:reply(code, data, as_json)
-    if self.message:is_firstline_sent() then
-        -- cannot send a status code twice
-        return false, errorf('cannot send a response message more than once')
-    end
-
-    -- set status code
-    local ok, err = self.message:set_status(code)
-    if not ok then
-        return false, err
-    elseif code == 204 then
-        -- ignore data for 204 No Content response
-        self.header:set('Content-Length', '0')
-        return self:write('')
-    end
+    check_reply_args(self.message, code, data)
 
     as_json = as_json == true
     if self.filter then
+        local err
         data, err = self.filter(code, data, as_json)
         if err then
             return false, errorf('failed to filter()', err)
         end
     end
 
-    if data == nil then
-        -- set default data for non-204 response code
-        data = code2message(code)
-        self.header:set('Content-Type', 'text/plain')
-    end
-
-    if as_json then
-        data = encode_json(data)
-        if not data then
-            return false, errorf('failed to encode data as JSON')
+    if data ~= nil then
+        if as_json then
+            data = encode_json(data)
+            if not data then
+                return false, errorf('failed to encode data as JSON')
+            end
+            self.header:set('Content-Type', 'application/json')
+        elseif not self.header:get('Content-Type') then
+            self.header:set('Content-Type', 'application/octet-stream')
+            if type(data) ~= 'string' then
+                data = tostring(data)
+            end
         end
-        self.header:set('Content-Type', 'application/json')
-    elseif not self.header:get('Content-Type') then
-        self.header:set('Content-Type', 'application/octet-stream')
-        if type(data) ~= 'string' then
-            data = tostring(data)
-        end
+        self.header:set('Content-Length', tostring(#data))
     end
-    self.header:set('Content-Length', tostring(#data))
 
     return self:write(data)
 end

--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -391,12 +391,12 @@ end
 local function response3xx(self, code, uri, data)
     if code ~= 300 and code ~= 304 then
         if type(uri) ~= 'string' or #uri == 0 or find(uri, '%s') then
-            return false, errorf('uri must be non-empty string with no spaces')
+            fatalf(2, 'uri must be non-empty string with no spaces')
         end
         self.header:set('Location', uri)
     elseif uri ~= nil then
         if type(uri) ~= 'string' or #uri == 0 or find(uri, '%s') then
-            return false, errorf('uri must be non-empty string with no spaces')
+            fatalf(2, 'uri must be non-empty string with no spaces')
         end
         -- set 'Content-Location' header for 304 Not Modified response, otherwise
         -- set 'Location' header.

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -743,10 +743,8 @@ function testcase.multiple_choices()
     })
 
     -- test that returns error if uri is not a string
-    ok, err, timeout = res:multiple_choices(123, 'hello')
-    assert.is_false(ok)
+    err = assert.throws(res.multiple_choices, res, 123, 'hello')
     assert.match(err, 'uri must be non-empty string')
-    assert.is_nil(timeout)
 end
 
 function testcase.not_modified()
@@ -778,10 +776,8 @@ function testcase.not_modified()
     })
 
     -- test that returns error if uri is not a string
-    ok, err, timeout = res:not_modified(123)
-    assert.is_false(ok)
+    err = assert.throws(res.not_modified, res, 123)
     assert.match(err, 'uri must be non-empty string')
-    assert.is_nil(timeout)
 end
 
 function testcase.reply3xx()
@@ -827,10 +823,8 @@ function testcase.reply3xx()
         })
 
         -- test that returns error if uri is not a string
-        ok, err, timeout = res[status](res, 123, 'hello')
-        assert.is_false(ok)
+        err = assert.throws(res[status], res, 123, 'hello')
         assert.match(err, 'uri must be non-empty string')
-        assert.is_nil(timeout)
     end
 end
 

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -378,44 +378,20 @@ function testcase.reply_file()
         },
     })
 
-    -- test that file() method cannot be called twice
-    ok, err, timeout = res:reply_file(200, pathname)
-    assert.is_false(ok)
+    -- test that throws an error if reply_file() method is called twice
+    err = assert.throws(res.reply_file, res, 200, pathname)
     assert.match(err, 'cannot send a response message more than once')
-    assert.is_nil(timeout)
 
-    -- test that Content-Length is 0 if 204 No Content status code
+    -- test that throws an error if 204 No Content with a content body
     clear_table(data)
     res = new_responder(writer)
-    ok, err, timeout = res:reply_file(204, pathname)
-    assert.is_nil(err)
-    assert.is_nil(timeout)
-    assert.is_true(ok)
-    -- confirm that data is written to writer
-    res:flush()
-    msg = create_response(data)
-    assert.contains(msg, {
-        reason = 'No Content',
-        status = 204,
-        version = 1.1,
-        content = '',
-        header = {
-            dict = {
-                ['content-length'] = {
-                    val = {
-                        '0',
-                    },
-                },
-            },
-        },
-    })
+    err = assert.throws(res.reply_file, res, 204, pathname)
+    assert.match(err, '204 No Content response cannot have a content body')
 
-    -- test that returns error if status is not a valid HTTP status code
+    -- test that throws an error if status is not a valid HTTP status code
     res = new_responder(writer)
-    ok, err, timeout = res:reply_file(999, pathname)
-    assert.is_false(ok)
+    err = assert.throws(res.reply_file, res, 999, pathname)
     assert.match(err, 'unsupported status code')
-    assert.is_nil(timeout)
 
     -- test that returns error if pathname is not a file
     res = new_responder(writer)
@@ -501,43 +477,19 @@ function testcase.reply()
         },
     })
 
-    -- test that reply() method cannot be called twice
-    ok, err, timeout = res:reply(200, 'foo')
-    assert.is_false(ok)
+    -- test that throws an error if reply() method is called twice
+    err = assert.throws(res.reply, res, 200, 'foo')
     assert.match(err, 'cannot send a response message more than once')
-    assert.is_nil(timeout)
 
-    -- test that returns error if status is not a valid HTTP status code
+    -- test that throws an error if status is not a valid HTTP status code
     res = new_responder(writer)
-    ok, err, timeout = res:reply(999, 'foo')
-    assert.is_false(ok)
+    err = assert.throws(res.reply, res, 999, 'foo')
     assert.match(err, 'unsupported status code')
-    assert.is_nil(timeout)
 
-    -- test that write a no-content response
+    -- test that throws an error if 204 No Content with a content body
     clear_table(data)
-    ok, err, timeout = res:reply(204, 'hello')
-    assert.is_nil(err)
-    assert.is_nil(timeout)
-    assert.is_true(ok)
-    -- confirm that data is written to writer
-    res:flush()
-    msg = create_response(data)
-    assert.contains(msg, {
-        reason = 'No Content',
-        status = 204,
-        version = 1.1,
-        content = '',
-        header = {
-            dict = {
-                ['content-length'] = {
-                    val = {
-                        '0',
-                    },
-                },
-            },
-        },
-    })
+    err = assert.throws(res.reply, res, 204, 'hello')
+    assert.match(err, '204 No Content response cannot have a content body')
 
     -- test that data will be stringified if it is not a string
     res = new_responder(writer)
@@ -582,21 +534,7 @@ function testcase.reply()
         reason = 'OK',
         status = 200,
         version = 1.1,
-        content = '200 OK',
-        header = {
-            dict = {
-                ['content-length'] = {
-                    val = {
-                        '6',
-                    },
-                },
-                ['content-type'] = {
-                    val = {
-                        'text/plain',
-                    },
-                },
-            },
-        },
+        content = '',
     })
 
     -- test that returns error if filter() returns an error
@@ -642,16 +580,46 @@ function testcase.reply()
     })
 end
 
-function testcase.reply1XX_2xx()
+function testcase.reply1XX()
     local data = {}
     local writer = new_writer(data)
 
-    -- test that 1xx Informational and 2xx Success responses
+    -- test that 1xx Informational
     for status, code in pairs({
         -- 1xx Informational responses
         continue = 100,
         switching_protocols = 101,
         processing = 102,
+    }) do
+        local res = new_responder(writer)
+        local ok, err, timeout = res[status](res)
+        assert.is_nil(err)
+        assert.is_nil(timeout)
+        assert.is_true(ok)
+        -- confirm that data is written to writer
+        res:flush()
+        local msg = create_response(data)
+        assert.contains(msg, {
+            reason = code2reason(code),
+            status = code,
+            version = 1.1,
+            content = '',
+        })
+
+        -- test that throws an error if reply wiht a content body
+        res = new_responder(writer)
+        err = assert.throws(res[status], res, 'hello')
+        assert.re_match(err, tostring(code) ..
+                            ' .+ response cannot have a content body')
+    end
+end
+
+function testcase.reply2xx()
+    local data = {}
+    local writer = new_writer(data)
+
+    -- test that 1xx Informational and 2xx Success responses
+    for status, code in pairs({
         -- 2xx Success responses
         ok = 200,
         created = 201,
@@ -665,7 +633,8 @@ function testcase.reply1XX_2xx()
         im_used = 226,
     }) do
         local res = new_responder(writer)
-        local ok, err, timeout = res[status](res, 'hello')
+        local body = (code ~= 204 and code ~= 205) and 'hello' or nil
+        local ok, err, timeout = res[status](res, body)
         assert.is_nil(err)
         assert.is_nil(timeout)
         assert.is_true(ok)
@@ -678,15 +647,13 @@ function testcase.reply1XX_2xx()
                 status = code,
                 version = 1.1,
                 content = '',
-                header = {
-                    dict = {
-                        ['content-length'] = {
-                            val = {
-                                '0',
-                            },
-                        },
-                    },
-                },
+            })
+        elseif code == 205 then
+            assert.contains(msg, {
+                reason = 'Reset Content',
+                status = code,
+                version = 1.1,
+                content = '',
             })
         else
             assert.contains(msg, {


### PR DESCRIPTION
This pull request introduces multiple changes to improve error handling, streamline response validation, and update test cases in the `Responder` module. The most significant updates include the introduction of a new `check_reply_args` helper function, replacing repetitive validation logic, and updating test cases to assert errors using `assert.throws` instead of returning error values.

### Enhancements to Error Handling and Validation:

* Introduced a new `check_reply_args` helper function in `lib/responder.lua` to centralize validation logic for response methods. This function checks for duplicate responses, invalid status codes, and ensures that certain status codes (e.g., `1xx`, `204`, `205`, `304`) do not include a content body.
* Replaced repetitive validation logic in `Responder:reply_file` and `Responder:reply` methods with calls to the new `check_reply_args` function, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L160-L177) [[2]](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L220-R247)

### Code Simplification:

* Simplified the file opening logic in `Responder:reply_file` by combining variable declarations and assignments into a single line.

### Updates to Test Cases:

* Updated test cases in `test/responder_test.lua` to use `assert.throws` for error assertions, ensuring consistent and explicit error testing. This change applies to tests for `reply_file`, `reply`, and `reply3xx` methods, among others. [[1]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L381-L418) [[2]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L504-R492) [[3]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L830-L833)
* Split the `reply1XX_2xx` test case into separate `reply1XX` and `reply2xx` test cases for better clarity and granularity. [[1]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L645-R622) [[2]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L668-R637)

### Minor Improvements:

* Replaced `errorf` with `fatalf` for certain error scenarios to improve the error handling mechanism. For example, invalid URIs in `response3xx` now throw a fatal error instead of returning an error value. [[1]](diffhunk://#diff-d32d3f55a1a29846b096e69263b12588b0134a973a1bac652f982257f1dc8537L394-R399) [[2]](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L746-L749)