### PR TITLE
Throw exception instead of returning error for constraint violations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - "5.2.:latest"
           - "5.3.:latest"
           - "5.4.:latest"
-          - "lj-v2.1:latest"
+        #   - "lj-v2.1:latest"
     steps:
     -
       name: Checkout

--- a/lib/responder.lua
+++ b/lib/responder.lua
@@ -203,9 +203,8 @@ function Responder:reply_file(code, file)
             if mime == nil then
                 mime = 'application/octet-stream'
             elseif type(mime) ~= 'string' then
-                return false, errorf(
-                           'mime:getmime() returns non-string value: %q',
-                           type(mime))
+                fatalf(2, 'mime:getmime() must return a string or nil, got %q',
+                       type(mime))
             end
         end
         self.header:set('Content-Type', mime)
@@ -246,9 +245,10 @@ function Responder:reply(code, data, as_json)
 
     if data ~= nil then
         if as_json then
-            data = encode_json(data)
+            local err
+            data, err = encode_json(data)
             if not data then
-                return false, errorf('failed to encode data as JSON')
+                return false, errorf('failed to encode data as JSON', err)
             end
             self.header:set('Content-Type', 'application/json')
         elseif not self.header:get('Content-Type') then

--- a/test/responder_test.lua
+++ b/test/responder_test.lua
@@ -437,10 +437,8 @@ function testcase.reply_file()
             return 123
         end,
     })
-    ok, err, timeout = res:reply_file(200, pathname)
-    assert.is_false(ok)
-    assert.match(err, 'mime:getmime() returns non-string value: "number"')
-    assert.is_nil(timeout)
+    err = assert.throws(res.reply_file, res, 200, pathname)
+    assert.match(err, 'mime:getmime() must return a string or nil')
 end
 
 function testcase.reply()


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/test.yml` file and the `lib/responder.lua` file, as well as corresponding test updates in `test/responder_test.lua`. The changes primarily focus on improving error handling in the `Responder` class and updating workflow configurations.

### Workflow Configuration Updates:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L36-R36): Commented out the `lj-v2.1:latest` entry in the test matrix, likely to temporarily disable testing for this version.

### Error Handling Improvements:
* `lib/responder.lua`:
  - Updated `Responder:reply_file` to throw a fatal error when `mime:getmime()` returns an invalid type, instead of returning an error value.
  - Enhanced `Responder:reply` to include detailed error information when JSON encoding fails, by capturing and passing the specific error message.

### Test Updates:
* [`test/responder_test.lua`](diffhunk://#diff-0988c8c52fb3cea1d066bea0429b4c2d4254e87e3c6e2d7d7147b7a76afdaa36L440-R441): Modified the `testcase.reply_file` test to validate the updated behavior of `Responder:reply_file`, ensuring it throws an error when `mime:getmime()` returns an invalid type.