### PR TITLE
Add support for wildcard segment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest

--- a/.luacov
+++ b/.luacov
@@ -1,6 +1,6 @@
 codefromstrings = false
 runreport = true
-deletestats = true
+deletestats = false
 modules = {
     ["net.http.connection"] = "lib/connection.lua",
     ["net.http.content"] = "lib/content.lua",
@@ -16,6 +16,7 @@ modules = {
     ["net.http.responder"] = "lib/responder.lua",
     ["net.http.router"] = "lib/router.lua",
     ["net.http.router.compiler"] = "lib/router/compiler.lua",
+    ["net.http.router.loadfenv"] = "lib/router/loadfenv.lua",
     ["net.http.router.parse"] = "lib/router/parse.lua",
     ["net.http.server"] = "lib/server.lua",
     ["net.http.status"] = "lib/status.lua",

--- a/lib/router.lua
+++ b/lib/router.lua
@@ -486,8 +486,8 @@ local function create_routepath(pathname, is_scriptfile, mime, trim_extentions)
         return dirname
     end
 
-    if prefix == ':' then
-        -- filename is a parameter segment
+    if prefix == ':' or prefix == '*' then
+        -- parameter or wildcard segment: include full segment in route path
         return dirname .. filename
     end
 
@@ -626,8 +626,9 @@ local function evalfile(r, pathinfo)
             methods[lower(method)] = handler
         end
         return fileinfo, nil, methods
-    elseif pathinfo.type == 'file' or pathinfo.type == 'param' then
-        -- 'file' and 'param' type pathnames require only the fileinfo
+    elseif pathinfo.type == 'file' or pathinfo.type == 'param' or pathinfo.type ==
+        'wildcard' then
+        -- 'file', 'param', and 'wildcard' type pathnames require only the fileinfo
         return fileinfo
     end
 

--- a/lib/router/parse.lua
+++ b/lib/router/parse.lua
@@ -191,6 +191,7 @@ local function verify_filter_pathinfo(segments, is_static)
         pathname = '/' .. concat(segments, '/'),
         filename = filename,
         name = res[3],
+        ext = res[5] and #res[5] > 0 and res[5] or nil,
         order = res[2] == '-' and '-' or tonumber(res[2]),
         is_static = is_static,
     }

--- a/lib/router/parse.lua
+++ b/lib/router/parse.lua
@@ -197,6 +197,33 @@ local function verify_filter_pathinfo(segments, is_static)
     }
 end
 
+-- wildcard/catch-all segment pattern (last segment only)
+local RE_WILDCARD_FILENAME_PAT = '^[*]([a-z0-9_]+)$'
+local RE_WILDCARD_FILENAME = assert(new_regex(RE_WILDCARD_FILENAME_PAT, 'i'))
+
+--- verify_wildcard_pathinfo checks the pathname is the wildcard pathinfo
+--- @param segments string[] pathname segments
+--- @param is_static boolean
+--- @return net.http.router.parse.pathinfo? info
+--- @return any err
+local function verify_wildcard_pathinfo(segments, is_static)
+    local filename = segments[#segments]
+    local res = RE_WILDCARD_FILENAME:match(filename)
+    if not res then
+        return nil,
+               errorf('wildcard segment %q must be matching the pattern %q',
+                      filename, '/' .. RE_WILDCARD_FILENAME_PAT .. '/i')
+    end
+
+    return {
+        type = 'wildcard',
+        pathname = '/' .. concat(segments, '/'),
+        filename = filename,
+        name = res[2],
+        is_static = is_static,
+    }
+end
+
 -- parameter-segment pattern
 local RE_PARAM_SEGMENT_PAT = concat({
     -- must start with ':'
@@ -286,6 +313,9 @@ local function parse(pathname, staticdirs, re_ignore, re_not_ignore)
     elseif prefix == ':' then
         -- parameter segment
         return verify_param_pathinfo(parts, is_static)
+    elseif prefix == '*' then
+        -- wildcard/catch-all segment (last segment only)
+        return verify_wildcard_pathinfo(parts, is_static)
     end
     return verify_file_pathinfo(parts, is_static, re_ignore, re_not_ignore)
 end

--- a/test/router/compiler_test.lua
+++ b/test/router/compiler_test.lua
@@ -1,0 +1,107 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local mkdtemp = require('mkdtemp')
+local rmdir = require('rmdir')
+local compiler = require('net.http.router.compiler')
+local loadfenv = require('net.http.router.loadfenv')
+
+local TESTDIR
+
+function testcase.before_each()
+    TESTDIR = assert(mkdtemp('./compiler_test_XXXXXX'))
+end
+
+function testcase.after_each()
+    if TESTDIR and not TESTDIR:find('^/') then
+        assert(rmdir(TESTDIR, true))
+        TESTDIR = nil
+    end
+end
+
+local function writefile(name, content)
+    local path = TESTDIR .. '/' .. name
+    local f = assert(io.open(path, 'w'))
+    f:write(content)
+    f:close()
+    return path
+end
+
+-- ============================================================
+-- compiler()
+-- ============================================================
+
+function testcase.compiler_fenv_not_table()
+    -- test that fenv must be a table
+    local err = assert.throws(compiler, '/dummy/path.lua', 'not_a_table')
+    assert.match(err, 'fenv must be table')
+end
+
+function testcase.compiler_fenv_nil()
+    -- test that fenv=nil is treated as not a table
+    local err = assert.throws(compiler, '/dummy/path.lua', nil)
+    assert.match(err, 'fenv must be table')
+end
+
+function testcase.compiler_file_not_found()
+    -- test that non-existent file returns loadfile error
+    local fenv = loadfenv()
+    local result, err = compiler(TESTDIR .. '/nonexistent.lua', fenv)
+    assert.equal(result, nil)
+    assert.re_match(err, 'failed to loadfile')
+end
+
+function testcase.compiler_file_syntax_error()
+    -- test that file with Lua syntax error returns loadfile error
+    local path = writefile('syntax_error.lua', 'this is not valid lua !!!')
+    local fenv = loadfenv()
+    local result, err = compiler(path, fenv)
+    assert.equal(result, nil)
+    assert.re_match(err, 'failed to loadfile')
+end
+
+function testcase.compiler_file_runtime_error()
+    -- test that file that throws at runtime returns pre-process error
+    local path = writefile('runtime_error.lua', 'error("intentional error")')
+    local fenv = loadfenv()
+    local result, err = compiler(path, fenv)
+    assert.equal(result, nil)
+    assert.re_match(err, 'failed to pre-process')
+end
+
+function testcase.compiler_valid_file()
+    -- test that valid file returning a table works correctly
+    local path = writefile('valid.lua', [[
+return {
+    get = function() return 'ok' end,
+    post = function() return 'posted' end,
+}
+]])
+    local fenv = loadfenv()
+    local result = assert(compiler(path, fenv))
+    assert.is_table(result)
+    assert.is_func(result.get)
+    assert.is_func(result.post)
+end
+
+function testcase.compiler_valid_file_returns_nil()
+    -- test that file returning nil is returned as-is
+    local path = writefile('returns_nil.lua', '-- no return')
+    local fenv = loadfenv()
+    local result = compiler(path, fenv)
+    assert.equal(result, nil)
+end
+
+function testcase.compiler_fenv_is_sandboxed()
+    -- test that the file runs in the provided environment (fenv)
+    -- require is NOT in the fenv, so accessing it should yield nil
+    local path = writefile('check_env.lua', [[
+local has_require = (require ~= nil)
+return { has_require = has_require }
+]])
+    local fenv = loadfenv()
+    -- fenv does not include 'require', so has_require should be false
+    -- (or raise an error if _ENV doesn't have it)
+    -- Just verify compilation succeeds with the sandbox
+    assert.not_throws(compiler, path, fenv)
+end

--- a/test/router/loadfenv_test.lua
+++ b/test/router/loadfenv_test.lua
@@ -1,0 +1,142 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local loadfenv = require('net.http.router.loadfenv')
+
+-- ============================================================
+-- loadfenv()
+-- ============================================================
+
+function testcase.loadfenv_returns_table()
+    -- test that loadfenv returns a table
+    local env = loadfenv()
+    assert.is_table(env)
+end
+
+function testcase.loadfenv_includes_version()
+    -- test that _VERSION is present
+    local env = loadfenv()
+    assert.is_string(env._VERSION)
+    assert.equal(env._VERSION, _VERSION)
+end
+
+function testcase.loadfenv_includes_safe_functions()
+    -- test that safe standard functions are present
+    local env = loadfenv()
+    -- assert may be the testcase assert module (table) or built-in (function)
+    assert(env.assert ~= nil)
+    assert.is_func(env.error)
+    assert.is_func(env.ipairs)
+    assert.is_func(env.next)
+    assert.is_func(env.pairs)
+    assert.is_func(env.pcall)
+    assert.is_func(env.print)
+    assert.is_func(env.rawequal)
+    assert.is_func(env.select)
+    assert.is_func(env.tonumber)
+    assert.is_func(env.tostring)
+    assert.is_func(env.type)
+    assert.is_func(env.xpcall)
+end
+
+function testcase.loadfenv_excludes_unsafe_functions()
+    -- test that dangerous functions are NOT present
+    local env = loadfenv()
+    assert.equal(env.require, nil)
+    assert.equal(env.loadfile, nil)
+    assert.equal(env.load, nil)
+    assert.equal(env.dofile, nil)
+    assert.equal(env.getmetatable, nil)
+    assert.equal(env.setmetatable, nil)
+    assert.equal(env.rawget, nil)
+    assert.equal(env.rawset, nil)
+    assert.equal(env.collectgarbage, nil)
+    assert.equal(env.getfenv, nil)
+    assert.equal(env.setfenv, nil)
+    assert.equal(env.module, nil)
+    assert.equal(env.loadstring, nil)
+end
+
+function testcase.loadfenv_includes_io_table()
+    -- test that io module subset is present
+    local env = loadfenv()
+    assert.is_table(env.io)
+    assert.is_func(env.io.open)
+    assert.is_func(env.io.close)
+    assert.is_func(env.io.read)
+    assert.is_func(env.io.write)
+    assert.is_func(env.io.lines)
+    assert.is_func(env.io.flush)
+    -- stdin/stdout/stderr are excluded
+    assert.equal(env.io.stdin, nil)
+    assert.equal(env.io.stdout, nil)
+    assert.equal(env.io.stderr, nil)
+end
+
+function testcase.loadfenv_includes_math_table()
+    -- test that math module is present
+    local env = loadfenv()
+    assert.is_table(env.math)
+    assert.is_func(env.math.floor)
+    assert.is_func(env.math.ceil)
+    assert.is_func(env.math.abs)
+    assert.is_func(env.math.max)
+    assert.is_func(env.math.min)
+    assert.is_func(env.math.random)
+end
+
+function testcase.loadfenv_includes_os_table()
+    -- test that os module subset is present
+    local env = loadfenv()
+    assert.is_table(env.os)
+    assert.is_func(env.os.clock)
+    assert.is_func(env.os.date)
+    assert.is_func(env.os.time)
+    assert.is_func(env.os.getenv)
+    -- execute and exit are excluded for security
+    assert.equal(env.os.execute, nil)
+    assert.equal(env.os.exit, nil)
+end
+
+function testcase.loadfenv_includes_string_table()
+    -- test that string module is present
+    local env = loadfenv()
+    assert.is_table(env.string)
+    assert.is_func(env.string.format)
+    assert.is_func(env.string.find)
+    assert.is_func(env.string.match)
+    assert.is_func(env.string.gmatch)
+    assert.is_func(env.string.gsub)
+    assert.is_func(env.string.sub)
+    assert.is_func(env.string.len)
+    assert.is_func(env.string.upper)
+    assert.is_func(env.string.lower)
+end
+
+function testcase.loadfenv_includes_table_module()
+    -- test that table module is present
+    local env = loadfenv()
+    assert.is_table(env.table)
+    assert.is_func(env.table.insert)
+    assert.is_func(env.table.remove)
+    assert.is_func(env.table.concat)
+    assert.is_func(env.table.sort)
+end
+
+function testcase.loadfenv_returns_independent_tables()
+    -- test that each call returns a new independent table
+    local env1 = loadfenv()
+    local env2 = loadfenv()
+    -- modifying one should not affect the other
+    env1.my_custom_key = 'test_value'
+    assert.equal(env2.my_custom_key, nil)
+end
+
+function testcase.loadfenv_utf8_table()
+    -- test that utf8 is included (Lua 5.4)
+    local env = loadfenv()
+    -- utf8 may be nil on older Lua versions, but should be a table or nil
+    if env.utf8 ~= nil then
+        assert.is_table(env.utf8)
+    end
+end

--- a/test/router/parse_test.lua
+++ b/test/router/parse_test.lua
@@ -1,0 +1,307 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local new_regex = require('regex').new
+local parse = require('net.http.router.parse')
+
+-- Default regex patterns matching router.lua defaults
+local RE_IGNORE = assert(new_regex('^\\.', 'i'))
+local RE_NOT_IGNORE = assert(new_regex(
+                                 '^[^.].*[.](gif|png|jpe?g|webp)$|^[^.].*[.](lua|js|css|txt|html?)$',
+                                 'i'))
+local RE_NOT_IGNORE_NONE = assert(new_regex('(?!)', 'i')) -- never matches
+
+local EMPTY_STATIC = {}
+
+-- ============================================================
+-- parse()
+-- ============================================================
+
+function testcase.parse_root_path()
+    -- test that root path returns file type with no static
+    local info = assert(parse('/', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.pathname, '/')
+    assert.equal(info.is_static, nil)
+end
+
+function testcase.parse_root_path_with_static()
+    -- test that root path with static returns is_static=true
+    local info = assert(parse('/', {
+        ['/'] = true,
+    }, RE_IGNORE, RE_NOT_IGNORE))
+    assert.equal(info.is_static, true)
+end
+
+function testcase.parse_pathname_no_leading_slash()
+    -- test that pathname without leading slash returns error
+    local _, err = parse('foo', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'pathname must be started with "/"')
+end
+
+function testcase.parse_pathname_trailing_slash()
+    -- test that pathname with trailing slash returns error
+    local _, err = parse('/foo/', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'pathname must be started with "/"')
+end
+
+-- ============================================================
+-- verify_file_pathinfo (plain filename, no prefix)
+-- ============================================================
+
+function testcase.parse_file_with_extension()
+    -- test that file with extension returns correct pathinfo
+    local info = assert(parse('/index.html', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.pathname, '/index.html')
+    assert.equal(info.filename, 'index.html')
+    assert.equal(info.name, 'index')
+    assert.equal(info.ext, '.html')
+    assert.equal(info.is_static, nil)
+end
+
+function testcase.parse_file_without_extension()
+    -- test that file without extension returns correct pathinfo
+    local info =
+        assert(parse('/robots', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.filename, 'robots')
+    assert.equal(info.name, 'robots')
+    assert.equal(info.ext, nil)
+end
+
+function testcase.parse_file_multi_extension()
+    -- test that file with multiple extensions uses last one for ext
+    local info = assert(parse('/archive.tar.gz', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.filename, 'archive.tar.gz')
+    assert.equal(info.name, 'archive')
+    assert.equal(info.ext, '.tar.gz')
+end
+
+function testcase.parse_file_in_nested_path()
+    -- test that nested path resolves file correctly
+    local info = assert(parse('/foo/bar/baz.html', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.pathname, '/foo/bar/baz.html')
+    assert.equal(info.filename, 'baz.html')
+    assert.equal(info.name, 'baz')
+end
+
+function testcase.parse_file_ignored()
+    -- test that hidden file (matches re_ignore, not re_not_ignore) returns error
+    local _, err = parse('/.hidden', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'ignored by configuration')
+end
+
+function testcase.parse_file_ignored_by_segment()
+    -- test that hidden segment (matches re_ignore) returns error
+    local _, err = parse('/.hidden/foo.html', EMPTY_STATIC, RE_IGNORE,
+                         RE_NOT_IGNORE)
+    assert.re_match(err, 'ignored by configuration')
+end
+
+function testcase.parse_file_invalid_filename()
+    -- test that invalid filename returns error
+    local _, err = parse('/%invalid', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+function testcase.parse_file_in_static_dir()
+    -- test that file in a configured static dir returns is_static=true
+    local staticdirs = {
+        ['/static'] = true,
+    }
+    local info = assert(parse('/static/foo.png', staticdirs, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.is_static, true)
+end
+
+function testcase.parse_file_in_nested_static_dir()
+    -- test that static detection propagates once set by parent dir
+    local staticdirs = {
+        ['/static'] = true,
+    }
+    local info = assert(parse('/static/img/logo.png', staticdirs, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.is_static, true)
+end
+
+function testcase.parse_file_not_in_static_dir()
+    -- test that file outside static dirs returns is_static=false
+    local staticdirs = {
+        ['/static'] = true,
+    }
+    local info = assert(parse('/api/handler.lua', staticdirs, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.is_static, nil)
+end
+
+-- ============================================================
+-- verify_content_pathinfo ('@' prefix)
+-- ============================================================
+
+function testcase.parse_content_handler()
+    -- test that '@'-prefixed filename returns content type
+    local info = assert(parse('/foo/@index', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'content')
+    assert.equal(info.pathname, '/foo/@index')
+    assert.equal(info.filename, '@index')
+    assert.equal(info.name, 'index')
+    assert.equal(info.ext, nil)
+    assert.equal(info.is_static, nil)
+end
+
+function testcase.parse_content_handler_with_extension()
+    -- test that '@'-prefixed filename with extension returns correct ext
+    local info = assert(parse('/foo/@handler.lua', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'content')
+    assert.equal(info.name, 'handler')
+    assert.equal(info.ext, '.lua')
+end
+
+function testcase.parse_content_handler_invalid_name()
+    -- test that '@' prefix followed by invalid name returns error
+    local _, err = parse('/foo/@', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+-- ============================================================
+-- verify_param_pathinfo (':' prefix, last segment)
+-- ============================================================
+
+function testcase.parse_param_segment()
+    -- test that ':'-prefixed last segment returns param type
+    local info = assert(parse('/foo/:bar', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'param')
+    assert.equal(info.pathname, '/foo/:bar')
+    assert.equal(info.filename, ':bar')
+    assert.equal(info.name, 'bar')
+    assert.equal(info.ext, nil)
+end
+
+function testcase.parse_param_segment_with_extension()
+    -- test that ':'-prefixed segment with extension returns correct ext
+    local info = assert(parse('/foo/:bar.html', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'param')
+    assert.equal(info.name, 'bar')
+    assert.equal(info.ext, '.html')
+end
+
+function testcase.parse_param_segment_invalid_name()
+    -- test that ':' prefix followed by invalid name returns error
+    local _, err = parse('/foo/:invalid-name', EMPTY_STATIC, RE_IGNORE,
+                         RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+-- ============================================================
+-- verify_filter_pathinfo ('#' prefix)
+-- ============================================================
+
+function testcase.parse_filter_handler()
+    -- test that '#order.name' returns filter type
+    local info = assert(parse('/foo/#1.myfilter', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'filter')
+    assert.equal(info.pathname, '/foo/#1.myfilter')
+    assert.equal(info.filename, '#1.myfilter')
+    assert.equal(info.name, 'myfilter')
+    assert.equal(info.ext, nil)
+    assert.equal(info.order, 1)
+end
+
+function testcase.parse_filter_handler_with_extension()
+    -- test that filter name includes extension (e.g. 'myfilter.lua')
+    local info = assert(parse('/foo/#5.myfilter.lua', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'filter')
+    assert.equal(info.name, 'myfilter.lua')
+    assert.equal(info.ext, '.lua')
+    assert.equal(info.order, 5)
+end
+
+function testcase.parse_filter_disable()
+    -- test that '#-.name' returns filter type with order='-'
+    local info = assert(parse('/foo/#-.myfilter', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'filter')
+    assert.equal(info.name, 'myfilter')
+    assert.equal(info.order, '-')
+end
+
+function testcase.parse_filter_handler_invalid_order()
+    -- test that order '0' is invalid (must start with [1-9])
+    local _, err = parse('/foo/#0.myfilter', EMPTY_STATIC, RE_IGNORE,
+                         RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+function testcase.parse_filter_handler_invalid_name()
+    -- test that missing name after '#order.' returns error
+    local _, err = parse('/foo/#1.', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+-- ============================================================
+-- verify_wildcard_pathinfo ('*' prefix)
+-- ============================================================
+
+function testcase.parse_wildcard_segment()
+    -- test that '*'-prefixed last segment returns wildcard type
+    local info = assert(parse('/foo/*path', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'wildcard')
+    assert.equal(info.pathname, '/foo/*path')
+    assert.equal(info.filename, '*path')
+    assert.equal(info.name, 'path')
+    assert.equal(info.ext, nil)
+end
+
+function testcase.parse_wildcard_segment_invalid_name()
+    -- test that '*' with invalid name (hyphen) returns error
+    local _, err =
+        parse('/foo/*my-path', EMPTY_STATIC, RE_IGNORE, RE_NOT_IGNORE)
+    assert.re_match(err, 'must be matching the pattern')
+end
+
+-- ============================================================
+-- Segment validation (middle segments)
+-- ============================================================
+
+function testcase.parse_param_middle_segment()
+    -- test that ':' param in middle is validated by RE_PARAM_SEGMENT
+    local info = assert(parse('/:bar/baz.html', EMPTY_STATIC, RE_IGNORE,
+                              RE_NOT_IGNORE))
+    assert.equal(info.type, 'file')
+    assert.equal(info.pathname, '/:bar/baz.html')
+end
+
+function testcase.parse_param_middle_segment_invalid()
+    -- test that invalid ':' segment in middle returns error
+    local _, err = parse('/:invalid-name/baz.html', EMPTY_STATIC, RE_IGNORE,
+                         RE_NOT_IGNORE)
+    assert.re_match(err, 'parameter segment.*must be matching the pattern')
+end
+
+function testcase.parse_invalid_middle_segment()
+    -- test that invalid regular segment (with invalid chars) returns error
+    local _, err = parse('/foo%bar/baz.html', EMPTY_STATIC, RE_IGNORE,
+                         RE_NOT_IGNORE)
+    assert.re_match(err, 'segment.*must be matching the pattern')
+end
+
+function testcase.parse_middle_segment_ignored()
+    -- test that ignored middle segment returns error
+    local re_ignore_all = assert(new_regex('private', 'i'))
+    local _, err = parse('/foo/private/index.html', EMPTY_STATIC, re_ignore_all,
+                         RE_NOT_IGNORE_NONE)
+    assert.re_match(err, 'ignored by configuration')
+end


### PR DESCRIPTION
This pull request adds support for wildcard/catch-all route segments (using `*`), improves the router parsing logic, and significantly expands test coverage for the router, environment sandboxing, and parsing modules. It also updates configuration for code coverage and CI workflow dependencies.

**Wildcard Route Support and Routing Logic Improvements:**

* Added support for wildcard/catch-all segments (e.g., `*path`) in route parsing and evaluation, including validation and correct type assignment in `lib/router.lua` and `lib/router/parse.lua`. [[1]](diffhunk://#diff-8030c94b979bb140284998753e3530e7fc4ee3cd2661792ba5f6f1be91e62af3L489-R490) [[2]](diffhunk://#diff-8030c94b979bb140284998753e3530e7fc4ee3cd2661792ba5f6f1be91e62af3L629-R631) [[3]](diffhunk://#diff-9c2595825422ea1a8f6af3bf0d870ba574bfe44d815354e8f5c70cdd87ad351cR194-R226) [[4]](diffhunk://#diff-9c2595825422ea1a8f6af3bf0d870ba574bfe44d815354e8f5c70cdd87ad351cR316-R318)
* Updated the route path creation logic to treat both parameter (`:`) and wildcard (`*`) segments as special, ensuring correct route path computation.

**Test Coverage and New Tests:**

* Added comprehensive tests for the router compiler, environment sandboxing (`loadfenv`), and parsing logic, including edge cases and security checks, in `test/router/compiler_test.lua`, `test/router/loadfenv_test.lua`, and `test/router/parse_test.lua`. [[1]](diffhunk://#diff-70bb6810188c18ef23a3661d9df11c67730b76b19c6ac9203d1fefc849cec22eR1-R107) [[2]](diffhunk://#diff-3e52d56d5024bc2e695e0e588ad6dd4d7e77dab825670fc387bf090253e53000R1-R142) [[3]](diffhunk://#diff-8e0d177676b46e905bb010e2591d1ee0b73cd78f80971d777c5956d84b61603dR1-R307)

**Configuration and Coverage Reporting:**

* Updated `.luacov` to disable deletion of coverage stats between runs and added module mappings for new router files. [[1]](diffhunk://#diff-030b6cdc19ece93e7680ef5791dde5f589f076325937767145efe2c5f230dbdaL3-R3) [[2]](diffhunk://#diff-030b6cdc19ece93e7680ef5791dde5f589f076325937767145efe2c5f230dbdaR19)

**CI Workflow:**

* Modified the GitHub Actions workflow to make the `test` job depend on the completion of the `luacheck` job, ensuring linting passes before running tests.